### PR TITLE
Update VPC Subnets in Setup Script

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/vpc-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/vpc-stack.yaml
@@ -10,17 +10,17 @@ Parameters:
   VpcCIDR:
     Description: The IP range (CIDR notation) for the VPC.
     Type: String
-    Default: 10.192.0.0/16
+    Default: 10.100.0.0/16
 
   PublicSubnet1CIDR:
     Description: The IP range (CIDR notation) for the public subnet in the first Availability Zone.
     Type: String
-    Default: 10.192.10.0/24
+    Default: 10.100.10.0/24
 
   PublicSubnet2CIDR:
     Description: The IP range (CIDR notation) for the public subnet in the second Availability Zone. 
     Type: String
-    Default: 10.192.11.0/24
+    Default: 10.100.20.0/24
 
 Resources:
 


### PR DESCRIPTION
This pull request modifies the VPC subnet configurations in the Kubernetes tutorial setup script. The changes include updating the CIDR blocks for the VPC and its public subnets to a new range:

- VPC CIDR changed from `10.192.0.0/16` to `10.100.0.0/16`
- Public Subnet 1 CIDR changed from `10.192.10.0/24` to `10.100.10.0/24`
- Public Subnet 2 CIDR changed from `10.192.11.0/24` to `10.100.20.0/24`

These updates ensure that the VPC and subnets are configured with a different IP range, which may be necessary for avoiding conflicts with existing networks.

---

> This pull request was co-created with Cosine Genie

Original Task: [awsome-distributed-training/adp66okot23o](https://cosine.sh/pandelis/awsome-distributed-training/task/adp66okot23o)
Author: Pandelis Zembashis
